### PR TITLE
Issue.#100

### DIFF
--- a/src/components/MachineNodes/StarterMachineNode/StarterMachineNode.jsx
+++ b/src/components/MachineNodes/StarterMachineNode/StarterMachineNode.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Card, CardMedia } from '@material-ui/core'
 import starter from '../../../assets/starter.png'
 import connector from './StarterMachineNodeConnector'
-import { applyDirection } from '../../../utils/directions'
+import { applyDirection, isPositionValid } from '../../../utils/directions'
 
 const StarterMachineNode = () => (
   <Card>
@@ -10,30 +10,20 @@ const StarterMachineNode = () => (
   </Card>
 )
 
-/*
-node: {
-  position
-  machine: {
-    frequency
-    direction
-    material
-    process
-  }
-  items
-*/
-
 class StarterMachineNodeStateful extends React.Component {
   componentWillUpdate(prevProps) {
-    const { tick, node, createRawMaterial } = this.props
+    const { tick, node, createRawMaterial, dimensions } = this.props
     const updatedTick = prevProps.tick
 
     if (updatedTick !== tick && tick % node.machine.frequency === 0) {
       const func = (dir, input, output) => {
-        const newDirection = applyDirection(node.position, node.machine.direction)
+        const outputPosition = applyDirection(node.position, node.machine.direction)
 
-        output.forEach(item => {
-          createRawMaterial(newDirection, { ...item, quantity: node.machine.frequency })
-        })
+        if (isPositionValid(outputPosition, dimensions)) {
+          output.forEach(item => {
+            createRawMaterial(outputPosition, { ...item, quantity: node.machine.frequency })
+          })
+        }
       }
 
       node.machine.process(node.items, func)

--- a/src/components/MachineNodes/StarterMachineNode/StarterMachineNodeConnector.js
+++ b/src/components/MachineNodes/StarterMachineNode/StarterMachineNodeConnector.js
@@ -1,11 +1,13 @@
 import { connect } from 'react-redux'
 import { createRawMaterial } from '../../../actions/Grid'
 import { getTick } from '../../../selectors/GameState'
+import { getDimensions } from '../../../selectors/GameDimensions'
 
 const connector = StarterMachineNode => {
   const mapStateToProps = (state, props) => ({
     ...props,
     tick: getTick(state),
+    dimensions: getDimensions(state),
   })
   const mapDispatchToProps = dispatch => ({
     createRawMaterial: (position, material) => dispatch(createRawMaterial(position, material)),

--- a/src/reducers/Grid.js
+++ b/src/reducers/Grid.js
@@ -8,27 +8,11 @@ import {
   MOVE_BLOCK,
 } from '../utils/actionTypes'
 import { Empty } from '../utils/machineUtils'
-
-const createInitialBlockState = (position, machine = { type: Empty }, items = {}) => ({
-  position,
-  machine,
-  items,
-})
-
-const generateGrid = (MAX_ROW, MAX_COLUMN) => {
-  const result = new Array(MAX_ROW)
-  for (let row = 0; row < MAX_ROW; row++) {
-    result[row] = new Array(MAX_COLUMN)
-    for (let column = 0; column < MAX_COLUMN; column++) {
-      result[row][column] = createInitialBlockState({ row, column })
-    }
-  }
-  return result
-}
+import { generateEmptyGrid } from '../utils/gridUtils'
 
 const initialState = {
   dimensions: DEFAULT_DIMENSIONS,
-  gridValues: generateGrid(10, 10),
+  gridValues: generateEmptyGrid(10, 10),
 }
 
 const modifyBlock = (gridValues, { row, column }, func) => {

--- a/src/reducers/Grid.js
+++ b/src/reducers/Grid.js
@@ -9,6 +9,7 @@ import {
 } from '../utils/actionTypes'
 import { Empty } from '../utils/machineUtils'
 import { generateEmptyGrid } from '../utils/gridUtils'
+import { isPositionValid } from '../utils/directions'
 
 const initialState = {
   dimensions: DEFAULT_DIMENSIONS,
@@ -17,6 +18,12 @@ const initialState = {
 
 const modifyBlock = (gridValues, { row, column }, func) => {
   const oldGridValues = gridValues
+
+  if (!isPositionValid({ row, column }, { n: oldGridValues.length, m: oldGridValues[0].length })) {
+    throw new Error(
+      `Invalid Grid Position: you are trying to modify the block in the position: ${row} ${column}`,
+    )
+  }
 
   oldGridValues[row] = gridValues[row].map((block, index) =>
     index === column ? func(block) : block,

--- a/src/reducers/Grid.js
+++ b/src/reducers/Grid.js
@@ -9,7 +9,6 @@ import {
 } from '../utils/actionTypes'
 import { Empty } from '../utils/machineUtils'
 import { generateEmptyGrid } from '../utils/gridUtils'
-import { isPositionValid } from '../utils/directions'
 
 const initialState = {
   dimensions: DEFAULT_DIMENSIONS,
@@ -18,12 +17,6 @@ const initialState = {
 
 const modifyBlock = (gridValues, { row, column }, func) => {
   const oldGridValues = gridValues
-
-  if (!isPositionValid({ row, column }, { n: oldGridValues.length, m: oldGridValues[0].length })) {
-    throw new Error(
-      `Invalid Grid Position: you are trying to modify the block in the position: ${row} ${column}`,
-    )
-  }
 
   oldGridValues[row] = gridValues[row].map((block, index) =>
     index === column ? func(block) : block,

--- a/src/reducers/Grid.spec.js
+++ b/src/reducers/Grid.spec.js
@@ -21,6 +21,17 @@ describe('grid reducer', () => {
     })
   })
 
+  describe('when we modify the grid in a invalid position it should throw an exception', () => {
+    const invalidPosition = createPosition(-1, -1)
+    const invalidUpdateBlockAction = updateBlock(invalidPosition, createStarterMachine({}))
+
+    it('should return the initial state', () => {
+      expect(() => {
+        reducer(initialState, invalidUpdateBlockAction)
+      }).toThrow()
+    })
+  })
+
   describe('updateBlock', () => {
     const updateBlockAction = updateBlock(position, createStarterMachine({}))
     const actualState = reducer(initialState, updateBlockAction)

--- a/src/reducers/Grid.spec.js
+++ b/src/reducers/Grid.spec.js
@@ -25,7 +25,7 @@ describe('grid reducer', () => {
     const invalidPosition = createPosition(-1, -1)
     const invalidUpdateBlockAction = updateBlock(invalidPosition, createStarterMachine({}))
 
-    it('should return the initial state', () => {
+    it('should throw an exception', () => {
       expect(() => {
         reducer(initialState, invalidUpdateBlockAction)
       }).toThrow()

--- a/src/reducers/Grid.spec.js
+++ b/src/reducers/Grid.spec.js
@@ -1,98 +1,131 @@
 import { Grid as reducer } from './Grid'
-import { Empty } from '../utils/machineUtils'
-import { updateBlock, deleteBlock, moveBlock } from '../actions/Grid'
+import { updateBlock, deleteBlock, moveBlock, createRawMaterial } from '../actions/Grid'
+import { createEmptyBlock, createStarterBlock, updateBlockWithItem } from '../utils/blockUtils'
+import { generateEmptyGrid, updateGridPosition } from '../utils/gridUtils'
+import { createPosition } from '../utils/positionUtils'
+import { createEmptyMachine, createStarterMachine } from '../utils/machineUtils'
+import { createMaterial } from '../utils/materialUtils'
 
-const createInitialBlockState = (position, machine = { type: Empty }, items = {}) => ({
-  position,
-  machine,
-  items,
+const createInitialState = (rows = 1, columns = 1) => ({
+  dimensions: { n: rows, m: columns },
+  gridValues: generateEmptyGrid(rows, columns),
 })
-
-const generateGrid = (MAX_ROW, MAX_COLUMN) => {
-  const result = new Array(MAX_ROW)
-  for (let row = 0; row < MAX_ROW; row++) {
-    result[row] = new Array(MAX_COLUMN)
-    for (let column = 0; column < MAX_COLUMN; column++) {
-      result[row][column] = createInitialBlockState({ row, column })
-    }
-  }
-  return result
-}
-
-const createInitialState = (n = 1, m = 1) => ({
-  dimensions: { n, m },
-  gridValues: generateGrid(n, m),
-})
-
-const createMachine = (machine = { type: 'Empty', direction: 'DOWN' }) => ({ machine })
-const createEmptyBlock = () => createMachine()
-const createStarterBlock = () => createMachine({ type: 'Starter', direction: 'DOWN' })
 
 describe('grid reducer', () => {
-  it('should return the initial state', () => {
-    expect(reducer(undefined, {})).toEqual(createInitialState(10, 10))
+  const initialState = createInitialState(2, 2)
+  const position = createPosition(0, 0)
+
+  describe('emptyReducer', () => {
+    it('should return the initial state', () => {
+      expect(reducer(undefined, {})).toEqual(createInitialState(10, 10))
+    })
   })
 
-  it('should update the block in row = 0 and column = 0 with a starter machine', () => {
-    const initialState = createInitialState(1, 1)
-    const updateBlockAction = updateBlock({ row: 0, column: 0 }, 'Starter')
+  describe('updateBlock', () => {
+    const updateBlockAction = updateBlock(position, createStarterMachine({}))
     const actualState = reducer(initialState, updateBlockAction)
 
-    const expectedState = initialState
-    expectedState.gridValues[0][0] = createStarterBlock()
+    describe('When we set a starter machine in the position 0 0', () => {
+      const expectedState = initialState
+      expectedState.gridValues = updateGridPosition(
+        expectedState.gridValues,
+        position,
+        createStarterBlock({ position }),
+      )
 
-    expect(actualState).toEqual(expectedState)
+      it('should update the block in row = 0 and column = 0 with a starter machine', () => {
+        expect(actualState).toEqual(expectedState)
+      })
+    })
+
+    describe('When we set the same starter machine two times in the block in the position 0 0', () => {
+      const firstState = reducer(initialState, updateBlockAction)
+      const lastState = reducer(firstState, updateBlockAction)
+      const expectedState = initialState
+      expectedState.gridValues = updateGridPosition(
+        expectedState.gridValues,
+        position,
+        createStarterBlock({ position }),
+      )
+      it('should let the starter machine in that position', () => {
+        expect(lastState).toEqual(expectedState)
+      })
+    })
+
+    describe('When we update the block in position 0 0 which has a starter machine with a empty block', () => {
+      const updateBlockWithStarterAction = updateBlock(position, createStarterMachine({}))
+      const firstState = reducer(initialState, updateBlockWithStarterAction)
+      const updateBlockWithEmptyAction = updateBlock(position, createEmptyMachine())
+      const lastState = reducer(firstState, updateBlockWithEmptyAction)
+
+      it('should let a empty machine in that block', () => {
+        const expectedState = initialState
+        expectedState.gridValues = updateGridPosition(
+          expectedState.gridValues,
+          position,
+          createEmptyBlock({}),
+        )
+        expect(lastState).toEqual(expectedState)
+      })
+    })
   })
 
-  it('should keep the same machine when update the same block two times with the same machine', () => {
-    const initialState = createInitialState(1, 1)
-    const updateBlockAction = updateBlock({ row: 0, column: 0 }, 'Starter')
+  describe('deleteBlock', () => {
+    const updateBlockAction = updateBlock(position, createStarterMachine({}))
     const firstState = reducer(initialState, updateBlockAction)
-    const lastState = reducer(firstState, updateBlockAction)
-    const expectedState = initialState
-    expectedState.gridValues[0][0] = createStarterBlock()
 
-    expect(lastState).toEqual(expectedState)
-  })
+    describe('When we delete a block which has a starter machine', () => {
+      const deleteAction = deleteBlock(position)
+      const lastState = reducer(firstState, deleteAction)
 
-  it('should modify the machine when update the block with a different machine', () => {
-    const initialState = createInitialState(1, 1)
-    const updateBlockWithStarterAction = updateBlock({ row: 0, column: 0 }, 'Starter')
-    const firstState = reducer(initialState, updateBlockWithStarterAction)
-
-    const updateBlockWithEmptyAction = updateBlock({ row: 0, column: 0 }, 'Empty')
-    const lastState = reducer(firstState, updateBlockWithEmptyAction)
-
-    const expectedState = initialState
-    expectedState.gridValues[0][0] = createEmptyBlock()
-
-    expect(lastState).toEqual(expectedState)
-  })
-
-  it('should delete the block which contains a machine', () => {
-    const initialState = createInitialState(1, 1)
-    const updateBlockAction = updateBlock({ row: 0, column: 0 }, 'Starter')
-    const firstState = reducer(initialState, updateBlockAction)
-
-    const deleteAction = deleteBlock({ row: 0, column: 0 })
-    const lastState = reducer(firstState, deleteAction)
-
-    const expectedState = initialState
-    expectedState.gridValues[0][0] = createEmptyBlock()
-
-    expect(lastState).toEqual(expectedState)
+      it('should delete the block which contains a machine', () => {
+        const expectedState = initialState
+        expectedState.gridValues = updateGridPosition(
+          expectedState.gridValues,
+          position,
+          createEmptyBlock({}),
+        )
+        expect(lastState).toEqual(expectedState)
+      })
+    })
   })
 
   describe('#moveSelectBlock', () => {
     describe('When the current node is Empty', () => {
-      const initialState = createInitialState(2, 2)
       it('should update the type of machine', () => {
-        const action = moveBlock(
-          { position: { row: 1, column: 1 }, machine: { type: 'bla' } },
-          { row: 1, column: 1 },
-        )
+        const action = moveBlock({ position, machine: { type: 'bla' } }, { row: 1, column: 1 })
         const newState = reducer(initialState, action)
+
         expect(newState.gridValues[1][1].machine.type).toEqual('bla')
+      })
+    })
+  })
+
+  describe('addMaterial', () => {
+    const material = createMaterial({ name: 'agua' })
+    const createMaterialAction = createRawMaterial(position, material)
+
+    describe('When we create a raw material in an Empty node with no items', () => {
+      const newState = reducer(initialState, createMaterialAction)
+      const expectedState = initialState
+
+      it('should add the material to the items in the node', () => {
+        const newBlock = updateBlockWithItem(createEmptyBlock({}), { ...material, quantity: 1 })
+        expectedState.gridValues = updateGridPosition(expectedState.gridValues, position, newBlock)
+
+        expect(newState).toEqual(expectedState)
+      })
+    })
+    describe('When we create a agua material two times in an Empty node with items', () => {
+      const oneItemState = reducer(initialState, createMaterialAction)
+      const expectedState = initialState
+      const twoItemsState = reducer(oneItemState, createMaterialAction)
+
+      it('should let the material agua with quantity = 2 in the node items', () => {
+        const newBlock = updateBlockWithItem(createEmptyBlock({}), { ...material, quantity: 2 })
+        expectedState.gridValues = updateGridPosition(expectedState.gridValues, position, newBlock)
+
+        expect(twoItemsState).toEqual(expectedState)
       })
     })
   })

--- a/src/reducers/Grid.spec.js
+++ b/src/reducers/Grid.spec.js
@@ -21,17 +21,6 @@ describe('grid reducer', () => {
     })
   })
 
-  describe('when we modify the grid in a invalid position it should throw an exception', () => {
-    const invalidPosition = createPosition(-1, -1)
-    const invalidUpdateBlockAction = updateBlock(invalidPosition, createStarterMachine({}))
-
-    it('should throw an exception', () => {
-      expect(() => {
-        reducer(initialState, invalidUpdateBlockAction)
-      }).toThrow()
-    })
-  })
-
   describe('updateBlock', () => {
     const updateBlockAction = updateBlock(position, createStarterMachine({}))
     const actualState = reducer(initialState, updateBlockAction)

--- a/src/utils/blockUtils.js
+++ b/src/utils/blockUtils.js
@@ -1,0 +1,24 @@
+import { createEmptyMachine, createStarterMachine } from './machineUtils'
+
+export const createEmptyBlock = ({ position, items = {} }) => ({
+  position,
+  machine: createEmptyMachine(),
+  items,
+})
+
+export const createStarterBlock = ({ position, machine, items = {} }) => ({
+  position,
+  machine: machine || createStarterMachine({}),
+  items,
+})
+
+// @Param block
+// @Param item
+export const updateBlockWithItem = ({ position, machine, items = {} }, item) => ({
+  position,
+  machine,
+  items: {
+    ...items,
+    [item.name]: item,
+  },
+})

--- a/src/utils/directions.js
+++ b/src/utils/directions.js
@@ -4,3 +4,6 @@ export const applyDirection = (position, direction) => {
   if (direction === 'DOWN') return { ...position, row: position.row + 1 }
   return { ...position, column: position.column - 1 }
 }
+
+export const isPositionValid = ({ row, column }, { n, m }) =>
+  row < n && row >= 0 && column >= 0 && column < m

--- a/src/utils/gridUtils.js
+++ b/src/utils/gridUtils.js
@@ -1,0 +1,21 @@
+import { createEmptyBlock } from './blockUtils'
+import { createPosition } from './positionUtils'
+
+export const generateEmptyGrid = (MAX_ROW, MAX_COLUMN) => {
+  const result = new Array(MAX_ROW)
+  for (let row = 0; row < MAX_ROW; row++) {
+    result[row] = new Array(MAX_COLUMN)
+    for (let column = 0; column < MAX_COLUMN; column++) {
+      result[row][column] = createEmptyBlock({ position: createPosition(row, column) })
+    }
+  }
+  return result
+}
+
+export const updateGridPosition = (grid, { row, column }, block) => {
+  const newGrid = grid
+
+  newGrid[row][column] = block
+
+  return newGrid
+}

--- a/src/utils/machineUtils.js
+++ b/src/utils/machineUtils.js
@@ -20,3 +20,30 @@ export const machineByType = {
   [Furnace]: FurnaceMachineNode,
   [Empty]: EmptyMachineNode,
 }
+
+export const createEmptyMachine = () => ({
+  name: Empty,
+  type: Empty,
+})
+
+const starterMachineMetadata = ({
+  selectedMaterial = { name: 'agua', price: 10 },
+  availableMaterials = [{ name: 'agua', price: 10 }],
+}) => ({
+  selectedMaterial,
+  availableMaterials,
+})
+export const createStarterMachine = ({
+  buy = 800,
+  sell = 400,
+  frequency = 1,
+  direction = 'DOWN',
+}) => ({
+  name: 'Starter',
+  type: Starter,
+  buy,
+  sell,
+  frequency,
+  direction,
+  metadata: starterMachineMetadata({}),
+})

--- a/src/utils/materialUtils.js
+++ b/src/utils/materialUtils.js
@@ -1,0 +1,4 @@
+export const createMaterial = ({ name = 'no-name', quantity = 1 }) => ({
+  name,
+  quantity,
+})

--- a/src/utils/positionUtils.js
+++ b/src/utils/positionUtils.js
@@ -1,0 +1,4 @@
+export const createPosition = (x, y) => ({
+  row: x,
+  column: y,
+})


### PR DESCRIPTION
# Pull Request Template

## Description

It solves the case when a starter machine tries to create a raw material in a invalid position.  
It adds a validation when the grid is going to be updated in a invalid position.

Fixes #100

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

There is a test in the file `src/reducers/grid.spec.js` 

- [x] `should throw an exception`
- [ ] I tested it on the app

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
